### PR TITLE
Fix how to access deadLetters from system in actor

### DIFF
--- a/akka-docs/rst/scala/code/docs/actor/ActorDocSpec.scala
+++ b/akka-docs/rst/scala/code/docs/actor/ActorDocSpec.scala
@@ -454,7 +454,7 @@ class ActorDocSpec extends AkkaSpec(Map("akka.loglevel" -> "INFO")) {
       class WatchActor extends Actor {
         val child = context.actorOf(Props.empty, "child")
         context.watch(child) // <-- this is the only call needed for registration
-        var lastSender = system.deadLetters
+        var lastSender = context.system.deadLetters
 
         def receive = {
           case "kill" =>


### PR DESCRIPTION
when a developer copy `system.deadLetters` from documentation, it does not work in Actor and system must get from context.